### PR TITLE
Use the maven wrapper instead of invoking natively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ cache:
     - $HOME/.m2/repository
 
 after_success:
-  - mvn com.blackducksoftware.integration:hub-maven-plugin:2.0.0:build-bom -Dhub.output.directory=. -Dhub.deploy.bdio=false
+  - ./mvnw com.blackducksoftware.integration:hub-maven-plugin:2.0.0:build-bom -Dhub.output.directory=. -Dhub.deploy.bdio=false
   - bash <(curl -s https://copilot.blackducksoftware.com/bash/travis) ./*_bdio.jsonld


### PR DESCRIPTION
This fixes an issue described in feedback to the BlackDuck CoPilot team

Without a pom.xml, calling via stock Maven commands for CoPilot will be unsuccessful - follow in build.sh's footsteps and use mvnw instead

We will look into how best to add clearer instructions for other users for this case - thank you for pointing it out!

