### PR TITLE
chore: Use JDK 21 for gradle 17 for code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     uses: rahulsom/_/.github/workflows/gradle.yml@main
     with:
-      java-version: 17
+      java-version: 21
     secrets:
       ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_sonatypeUsername }}
       ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_sonatypePassword }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
   alias(libs.plugins.waena.published)
 }
 
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+  }
+}
+
 repositories {
   mavenCentral()
 }


### PR DESCRIPTION
This allows upgrading gradle and waena.
