### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: rahulsom/_/.github/workflows/gradle.yml@main
     with:
       java-version: 21


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/ihe-iti/security/code-scanning/1](https://github.com/rahulsom/ihe-iti/security/code-scanning/1)

To fix the issue, you should add an explicit `permissions` block to limit the GITHUB_TOKEN's access for the workflow or the job. Since this workflow simply delegates all work to a reusable workflow, you should set the most restrictive permissions possible unless you know that this workflow or the delegated workflow requires additional access (like write access for PRs, releases, etc). As a general safe default, you can set `contents: read` at the job level (inside `build:`), which will minimally allow read access to source content, but not write to repository resources. Insert the following YAML block at the same indentation level as `uses:` (directly under the job line 12), before `uses:`. If the reusable workflow needs additional permissions, you can extend from this base.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
